### PR TITLE
refactor: optimize array-to-record conversion

### DIFF
--- a/packages/twenty-shared/src/utils/from-array-to-unique-key-record.util.ts
+++ b/packages/twenty-shared/src/utils/from-array-to-unique-key-record.util.ts
@@ -1,25 +1,35 @@
 import { type StringPropertyKeys } from '@/utils/trim-and-remove-duplicated-whitespaces-from-object-string-properties';
 import { isDefined } from '@/utils/validation';
 
-export const fromArrayToUniqueKeyRecord = <T extends object>({
+/**
+ * Converts an array of objects into a record keyed by a unique property.
+ *
+ * Previous implementation recreated the accumulator object on each iteration
+ * using object spread, resulting in `O(n^2)` complexity and unnecessary
+ * allocations. This version mutates a single accumulator object instead,
+ * dramatically improving performance for large arrays while retaining the
+ * duplicate-key protection.
+ */
+export const fromArrayToUniqueKeyRecord = <T extends Record<string, any>>({
   array,
   uniqueKey,
 }: {
   array: T[];
   uniqueKey: StringPropertyKeys<T>;
-}) => {
-  return array.reduce<Record<string, T>>((acc, occurrence) => {
+}): Record<string, T> => {
+  const record: Record<string, T> = {};
+
+  for (const occurrence of array) {
     const currentUniqueKey = occurrence[uniqueKey] as string;
 
-    if (isDefined(acc[currentUniqueKey])) {
+    if (isDefined(record[currentUniqueKey])) {
       throw new Error(
         `Should never occur, flat array contains twice the same unique key ${occurrence[uniqueKey]}`,
       );
     }
 
-    return {
-      ...acc,
-      [currentUniqueKey]: occurrence,
-    };
-  }, {});
+    record[currentUniqueKey] = occurrence;
+  }
+
+  return record;
 };


### PR DESCRIPTION
## Summary
- refactor array-to-record util to mutate a single accumulator for improved performance

## Testing
- `npx nx lint twenty-shared`
- `npx nx test twenty-shared --skip-nx-cache`


------
https://chatgpt.com/codex/tasks/task_b_68aab3a73470832bb326e2a2831f35c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized internal data mapping to improve performance and reduce memory usage, with no change to observable behavior. Duplicate-key protection remains enforced.
- Documentation
  - Added clearer explanations of behavior and duplicate handling for the related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->