### PR TITLE
refactor: log object metadata query duration

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { type Query, type QueryOptions } from '@ptc-org/nestjs-query-core';
@@ -58,6 +58,8 @@ import { type CreateObjectInput } from './dtos/create-object.input';
 
 @Injectable()
 export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEntity> {
+  private readonly logger = new Logger(ObjectMetadataService.name);
+
   constructor(
     @InjectRepository(ObjectMetadataEntity, 'core')
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
@@ -85,12 +87,11 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
   ): Promise<ObjectMetadataEntity[]> {
     const start = performance.now();
 
-    const result = super.query(query, opts);
+    const result = await super.query(query, opts);
 
     const end = performance.now();
 
-    // eslint-disable-next-line no-console
-    console.log(`metadata query time: ${end - start} ms`);
+    this.logger.debug(`metadata query time: ${end - start} ms`);
 
     return result;
   }


### PR DESCRIPTION
## Summary
- use NestJS Logger in ObjectMetadataService
- await parent query before measuring duration

## Testing
- `yarn nx lint twenty-server` *(fails: Couldn't find the node_modules state file)*
- `yarn nx test twenty-server` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_68b7c566a530832b9a1f6e4cd0bbfea4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Refactor
  - Replaced console logging with structured debug logging for query execution.
  - Ensured timing captures the full duration by awaiting query completion.
- Chores
  - Introduced an internal logger to standardize diagnostics.
- Performance
  - More accurate query timing metrics to aid monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->